### PR TITLE
[DO NOT MERGE] Customize apipie-rails

### DIFF
--- a/lib/apipie/application.rb
+++ b/lib/apipie/application.rb
@@ -271,7 +271,7 @@ module Apipie
       # if resource_name is blank, take just resources which have some methods because
       # we dont want to show eg ApplicationController as resource
       # otherwise, take only the specified resource
-      _resources = resource_descriptions[version].inject({}) do |result, (k,v)|
+      resources = resource_descriptions[version].inject({}) do |result, (k,v)|
          if resource_name.blank?
            result[k] = v unless v._methods.blank?
          else
@@ -280,7 +280,7 @@ module Apipie
          result
        end
 
-      @swagger_generator.generate_from_resources(version,_resources, method_name, lang, clear_warnings)
+      @swagger_generator.generate_from_resources(version, resources, method_name, lang, clear_warnings)
     end
 
     def to_json(version, resource_name, method_name, lang)

--- a/lib/apipie/swagger_generator.rb
+++ b/lib/apipie/swagger_generator.rb
@@ -71,6 +71,7 @@ module Apipie
           },
           basePath: Apipie.api_base_url(version),
           consumes: [],
+          produces: ['application/json'], # TBD
           paths: {},
           definitions: {},
           tags: [],

--- a/lib/apipie/swagger_generator.rb
+++ b/lib/apipie/swagger_generator.rb
@@ -648,7 +648,7 @@ module Apipie
       path_param_defs_hash.each{|name,desc| desc.required = true}
       add_params_from_hash(swagger_result, path_param_defs_hash, nil, "path")
 
-      if params_in_body? && body_allowed_for_current_method
+      if params_in_body?
         if params_in_body_use_reference?
           swagger_schema_for_body = {"$ref" => gen_referenced_block_from_params_array("#{swagger_op_id_for_method(method)}_input", body_param_defs_array)}
         else

--- a/lib/apipie/swagger_generator.rb
+++ b/lib/apipie/swagger_generator.rb
@@ -595,6 +595,27 @@ module Apipie
             schema = new_schema
           end
           param_defs[param_desc.name.to_sym] = schema if !schema.nil?
+        elsif !param_desc.is_array_of.nil?
+          dsl_data_params = @apipie.get_param_group(param_desc.method_description.resource.controller, param_desc.is_array_of).call
+          params_array_for_param_group = dsl_data_params.map do |args|
+            Apipie::ParamDescription.from_dsl_data(param_desc.method_description, args)
+          end.compact
+          ref_to = gen_referenced_block_from_params_array(param_desc.is_array_of, params_array_for_param_group, allow_nulls=false)
+          schema = {
+            'type': 'array',
+            'items': {
+              '$ref' =>  ref_to
+            }
+          }
+          param_defs[param_desc.name.to_sym] = schema if !schema.nil?
+        elsif !param_desc.is_alias_of.nil?
+          dsl_data_params = @apipie.get_param_group(param_desc.method_description.resource.controller, param_desc.is_alias_of).call
+          params_array_for_param_group = dsl_data_params.map do |args|
+            Apipie::ParamDescription.from_dsl_data(param_desc.method_description, args)
+          end.compact
+          ref_to = gen_referenced_block_from_params_array(param_desc.is_alias_of, params_array_for_param_group, allow_nulls=false)
+          schema = { '$ref' =>  ref_to }
+          param_defs[param_desc.name.to_sym] = schema if !schema.nil?
         else
           param_defs[param_desc.name.to_sym] = swagger_atomic_param(param_desc, true, nil, allow_nulls)
         end

--- a/lib/apipie/swagger_generator.rb
+++ b/lib/apipie/swagger_generator.rb
@@ -456,6 +456,7 @@ module Apipie
     # The output is slightly different when the parameter is inside a schema block.
     #--------------------------------------------------------------------------
     def swagger_atomic_param(param_desc, in_schema, name, allow_nulls)
+      allow_nulls = param_desc.allow_nil
       def save_field(entry, openapi_key, v, apipie_key=openapi_key, translate=false)
         if v.key?(apipie_key)
           if translate

--- a/lib/apipie/swagger_generator.rb
+++ b/lib/apipie/swagger_generator.rb
@@ -103,13 +103,13 @@ module Apipie
     #--------------------------------------------------------------------------
 
     def add_resources(resources)
-      resources.each do |resource_name, resource_defs|
-        add_resource_description(resource_name, resource_defs)
-        add_resource_methods(resource_name, resource_defs)
+      resources.each do |_, resource_defs|
+        add_resource_description(resource_defs)
+        add_resource_methods(resource_defs)
       end
     end
 
-    def add_resource_methods(resource_name, resource_defs)
+    def add_resource_methods(resource_defs)
       resource_defs._methods.each do |apipie_method_name, apipie_method_defs|
         add_ruby_method(@paths, apipie_method_defs)
       end
@@ -179,7 +179,7 @@ module Apipie
       resource._id
     end
 
-    def add_resource_description(resource_name, resource)
+    def add_resource_description(resource)
       if resource._full_description
         @tags << {
             name: tag_name_for_resource(resource),

--- a/lib/apipie/validator.rb
+++ b/lib/apipie/validator.rb
@@ -127,6 +127,10 @@ module Apipie
           'hash'
         elsif @type.ancestors.include? Array
           'array'
+        elsif @type == Integer
+          'integer'
+        elsif @type == Float
+          'float'
         elsif @type.ancestors.include? Numeric
           'numeric'
         else


### PR DESCRIPTION
# Overview
トレタ用に[apipie-rails](https://github.com/Apipie/apipie-rails)をカスタマイズしました。
およそ半分がトレタに依存しない内容で、これは本家にissue/PRを作成中なので、そのうち本家で取り込まれる想定です。
残り半分は本家で取り込まれるかやや微妙な改修になります。

独自レポジトリでの対応はできれば避けたいので、本家に改修を取り込んでもらえるよう働きかける予定ですが、
本家の対応スピードがやや遅く、また中身のコードベースもややとっ散らかってるため、独自レポジトリとしての対応の可能性もあるかもしれません。
これがどうしても負債となるようであれば、最終的には脱apipie-railsを検討します。が、現時点ではapipie-railsを使っていく方針で問題ないと考えています。

# 注意
この `customize` ブランチをGemfileで指定する予定です。
差分が分かりやすいよう、PRとして残しておきます。 **masterへのマージはしないでください**。

# 差分
Checked means merged to https://github.com/Apipie/apipie-rails.

## 本家にissue/PRを出しているもの(or出す予定のもの)
* [x] Use configured value when swagger_content_type_input argument is not passed
 https://github.com/Apipie/apipie-rails/pull/648
* [ ] Refactoring https://github.com/toreta/apipie-rails/pull/1/commits/64f4a0c13242f3cf9aa7abdc51cf35e68a48ceb7
* [ ] Allow null when allow_nil is defined https://github.com/Apipie/apipie-rails/issues/650 https://github.com/toreta/apipie-rails/pull/1/commits/baef6d03267faceed6c83fd41b28ce9f3acbcd24
* [ ] Output 'produces' section https://github.com/Apipie/apipie-rails/issues/649 https://github.com/toreta/apipie-rails/pull/1/commits/36ad5eb231554a30b04e918da5ebd92386e7afe2
* [ ] Allow parameters in body every methods https://github.com/toreta/apipie-rails/pull/1/commits/27230f979560a52c42290cfd0e7ef9d349ee51cb
* [ ] Expect integer type when type is integer https://github.com/toreta/apipie-rails/pull/1/commits/2abcca677be50af2087d2857411c11fc08b50406

## 本家取り込みがやや難しいかも
* [ ] Enhance Syntax https://github.com/toreta/apipie-rails/pull/1/commits/3d02b9e1df6afb9f63eb6f4a912c3e206943f3be

`param_group` を色んな構文で使うための改修です。 
(例)`property :pet, :pet` や `property :pets, array_of: :pet` 
あってしかるべき構文ではありつつ、コードがそれなりに書き換わる改修であり、この改修方法で正しいのかまだ自信がないので、取り込みまで少し時間がかかるかもしれません。
トレタ側の改修が落ち着いたら本格的に働きかけようと思っています。